### PR TITLE
[FIX] expense: update css and improve expense Form

### DIFF
--- a/expense_tracker/static/src/expense_tracker.scss
+++ b/expense_tracker/static/src/expense_tracker.scss
@@ -80,9 +80,6 @@
     }
 }
 
-.form-control:focus {
-    color: $o-black !important;
-}
 
 .o_content_modal_rounded_shades {
     background-color: #333;

--- a/expense_tracker/static/src/screens/expense_form/expense_form.js
+++ b/expense_tracker/static/src/screens/expense_form/expense_form.js
@@ -80,7 +80,7 @@ class ExpenseForm extends Component {
             name: this.form.el.querySelector(".o_expense_description").value,
             date: this.form.el.querySelector(".o_expense_date").value,
             amount: this.form.el.querySelector(".o_expense_amount").value,
-            category_id: parseInt(this.form.el.querySelector("o_expense_category").value),
+            category_id: parseInt(this.form.el.querySelector(".o_expense_category").value),
         };
         if (this.state.data.record) {
             this._updateExpense(newExpense).then(() => {

--- a/expense_tracker/static/src/screens/expense_list/expense_list.xml
+++ b/expense_tracker/static/src/screens/expense_list/expense_list.xml
@@ -21,6 +21,7 @@
             <table class="table table-dark table-hover mb-0">
                 <thead>
                     <tr class="table-success">
+                        <th></th>
                         <th>Description</th>
                         <th>Date</th>
                         <th>Amount</th>
@@ -41,10 +42,12 @@
                 <tfoot>
                     <tr class="table-dark">
                         <td colspan="2"></td>
-                        <td>
-                            <b>Total Amount: <t t-esc="totalAmount"/></b>
+                        <td class="text-end">
+                            <b>Total Amount :</b>
                         </td>
-                        <td></td>
+                        <td>
+                            <b> <t t-esc="totalAmount"/> </b>
+                        </td>
                         <td></td>
                     </tr>
                 </tfoot>

--- a/expense_tracker/views/expense_views.xml
+++ b/expense_tracker/views/expense_views.xml
@@ -49,7 +49,7 @@
         <field name="arch" type="xml">
             <tree string="Expense Tags">
                 <field name="name"/>
-                <field name="color"/>
+                <field name="color" widget="color_picker"/>
             </tree>
         </field>
     </record>
@@ -66,7 +66,7 @@
                         <field name="date"/>
                         <field name="amount"/>
                         <field name="category_id"/>
-                        <field name="tag_ids"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     </group>
                 </sheet>
             </form>

--- a/expense_tracker_dashboard/static/src/dashboard/dashboard.xml
+++ b/expense_tracker_dashboard/static/src/dashboard/dashboard.xml
@@ -25,7 +25,7 @@
 
     <t t-name="awesome_dashboard.ConfigurationDialog">
         <Dialog title="'Dashboard items configuration'">
-            Which cards do you whish to see ?
+            Which cards do you wish to see ?
             <t t-foreach="items" t-as="item" t-key="item.id">
                 <CheckBox value="item.enabled" onChange="(ev) => this.onChange(ev, item)">
                     <t t-esc="item.description"/>


### PR DESCRIPTION
This PR addresses several issues and improvements in the expense module:

- Removed form input focus CSS for a cleaner UI.
- Fixed the error related to the expense category in the expense form.
- Adjusted the layout of the dashboard expense list view headers for better alignment.
- Added a total expense display below all expenses with proper text alignment.
- Corrected various spelling mistakes.
- Added color to expense tags.

I am pleased to contribute to the OCD24. 😄